### PR TITLE
Add a shortcut to pull a branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "blaze_explorer"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["tomblazejewski <tomi.blazejewski@gmail.com>"]
 name = "blaze_explorer"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@ Currently under development and unstable.
 | `<space>hc` | Git add and commit (waits to enter the message) |
 | `<space>ht` | Show git status                                 |
 | `<space>hP` | Push current branch to remote                   |
+| `<space>hO` | Pull current branch from remote                 |
 
 ## Telescope
 

--- a/src/app_input_machine.rs
+++ b/src/app_input_machine.rs
@@ -6,7 +6,7 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::{
     action::{Action, AppAction, CommandAction, ExplorerAction, PopupType, TextAction},
-    function_helpers::push_current_branch,
+    function_helpers::{pull_current_branch, push_current_branch},
     input_machine::{InputMachine, KeyMapNode, KeyProcessingResult},
     mode::Mode,
 };
@@ -212,6 +212,14 @@ pub fn default_key_map() -> KeyMapNode<Action> {
             KeyEvent::new(KeyCode::Char('P'), KeyModifiers::NONE),
         ],
         Action::AppAct(AppAction::ExecuteFunction(Box::new(push_current_branch))),
+    );
+    root.add_sequence(
+        vec![
+            KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('O'), KeyModifiers::NONE),
+        ],
+        Action::AppAct(AppAction::ExecuteFunction(Box::new(pull_current_branch))),
     );
 
     root

--- a/src/function_helpers.rs
+++ b/src/function_helpers.rs
@@ -29,3 +29,27 @@ pub fn push_current_branch(_app: &mut App) -> Option<Action> {
         )))),
     }
 }
+pub fn pull_current_branch(_app: &mut App) -> Option<Action> {
+    let branch_name = Command::new("git")
+        .arg("rev-parse")
+        .arg("--abbrev-ref")
+        .arg("HEAD")
+        .output();
+
+    match branch_name {
+        Ok(output) => {
+            let mut branch_name = String::from_utf8(output.stdout).unwrap();
+            if branch_name.ends_with("\n") {
+                branch_name.pop();
+            }
+            Some(Action::AppAct(AppAction::ParseCommand(format!(
+                "!git pull origin {}",
+                branch_name
+            ))))
+        }
+        Err(err) => Some(Action::AppAct(AppAction::DisplayMessage(format!(
+            "Failed to get current branch: {}",
+            err
+        )))),
+    }
+}


### PR DESCRIPTION
# Release notes

Add a shortcut to pull the current branch from remove.

# Pull request overview

This merge introduces a new shortcut `<leader>hO` to pull the current branch from remote.

# Outline of changes

- Add a new function to pull the branch and attach a shortcut to it.

# Quality checks

- [x] Removed all unnecessary imports (as much as reasonably possible)
- [ ] Added units tests for the new code
- [x] All unit tests pass
- [x] Added all new shortcuts to `README.md`
- [x] Updated the `README.md` roadmap
- [x] Removed unnecessary debug outputs
- [x] Updated version number
