### PR TITLE
Track an incomplete current sequence in the status bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "blaze_explorer"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["tomblazejewski <tomi.blazejewski@gmail.com>"]
 name = "blaze_explorer"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/app.rs
+++ b/src/app.rs
@@ -344,8 +344,11 @@ impl App {
     pub fn render(&mut self) -> Result<()> {
         self.terminal.draw(|frame| {
             let areas = get_component_areas(frame);
-            self.explorer_manager
-                .draw(frame, *areas.get("explorer_table").unwrap());
+            self.explorer_manager.draw(
+                frame,
+                *areas.get("explorer_table").unwrap(),
+                self.current_sequence.clone(),
+            );
             let _ = self
                 .command_line
                 .draw(frame, *areas.get("command_line").unwrap());

--- a/src/components/explorer_manager.rs
+++ b/src/components/explorer_manager.rs
@@ -2,11 +2,13 @@ use core::panic;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use ratatui::crossterm::event::KeyEvent;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::Frame;
 
 use super::explorer_table::{ExplorerTable, FileData, GlobalStyling};
 use crate::components::Component;
+use crate::explorer_helpers::convert_sequence_to_string;
 use crate::history_stack::directory_history::DirectoryHistory;
 use crate::mode::Mode;
 
@@ -173,7 +175,8 @@ impl ExplorerManager {
         false
     }
 
-    pub fn draw(&mut self, frame: &mut Frame, area: Rect) {
+    pub fn draw(&mut self, frame: &mut Frame, area: Rect, sequence: Vec<KeyEvent>) {
+        let string_seq = convert_sequence_to_string(sequence);
         let mut draw_map: HashMap<usize, Rect> = HashMap::new();
         self.get_drawable(frame, area, 0, &mut draw_map);
         self.last_layout = draw_map.clone();
@@ -182,7 +185,7 @@ impl ExplorerManager {
             .map(|(key, value)| {
                 let table = self.explorers.get_mut(key).unwrap();
                 if let Split::Single(table) = &mut table.split {
-                    let _ = table.draw(frame, *value);
+                    let _ = table.draw(frame, *value, string_seq.clone());
                 }
             })
             .collect();

--- a/src/components/explorer_table.rs
+++ b/src/components/explorer_table.rs
@@ -523,10 +523,8 @@ impl ExplorerTable {
         }
         row.style(style)
     }
-}
 
-impl Component for ExplorerTable {
-    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+    pub fn draw(&mut self, frame: &mut Frame, area: Rect, string_sequence: String) -> Result<()> {
         // get table block
         self.refresh_contents();
         let widths = [
@@ -600,9 +598,25 @@ impl Component for ExplorerTable {
             None => Span::from(String::from("")),
         };
 
+        let sequence_line = Line::from(string_sequence).alignment(Alignment::Right);
+
         let status_line = match self.focused {
             true => Line::from(vec![mode_span, plugin_span, path_span]),
             false => Line::from(vec![path_span]),
+        };
+
+        let status_bar = match self.focused {
+            true => Table::new(
+                vec![Row::new(vec![
+                    Cell::from(Text::from(status_line)),
+                    Cell::from(Text::from(sequence_line)),
+                ])],
+                vec![Constraint::Fill(1), Constraint::Length(10)],
+            ),
+            false => Table::new(
+                vec![Row::new(vec![Cell::from(Text::from(status_line))])],
+                vec![Constraint::Fill(1)],
+            ),
         };
 
         //divide the available area into one for the table and one for the paragraph
@@ -611,7 +625,7 @@ impl Component for ExplorerTable {
             .constraints([Constraint::Fill(1), Constraint::Length(1)])
             .split(area);
         frame.render_stateful_widget(t, explorer_area_blocks[0], &mut self.state);
-        frame.render_widget(status_line, explorer_area_blocks[1]);
+        frame.render_widget(status_bar, explorer_area_blocks[1]);
 
         Ok(())
     }

--- a/src/explorer_helpers.rs
+++ b/src/explorer_helpers.rs
@@ -1,7 +1,20 @@
 use ratatui::{
+    crossterm::event::{KeyCode, KeyEvent},
     style::Style,
     text::{Line, Span},
 };
+
+pub fn convert_sequence_to_string(sequence: Vec<KeyEvent>) -> String {
+    sequence
+        .iter()
+        .map(|event| match event.code {
+            KeyCode::Char(' ') => "<space>".to_string(),
+            KeyCode::Char(c) => c.to_string(),
+            _ => "".to_string(),
+        })
+        .collect::<Vec<String>>()
+        .join("")
+}
 
 pub fn highlight_search_result(line_text: String, query: &str, highlighted_style: Style) -> Line {
     if line_text.contains(query) {

--- a/src/explorer_helpers.rs
+++ b/src/explorer_helpers.rs
@@ -1,5 +1,5 @@
 use ratatui::{
-    crossterm::event::{KeyCode, KeyEvent},
+    crossterm::event::{KeyCode, KeyEvent, KeyModifiers},
     style::Style,
     text::{Line, Span},
 };
@@ -7,10 +7,13 @@ use ratatui::{
 pub fn convert_sequence_to_string(sequence: Vec<KeyEvent>) -> String {
     sequence
         .iter()
-        .map(|event| match event.code {
-            KeyCode::Char(' ') => "<space>".to_string(),
-            KeyCode::Char(c) => c.to_string(),
-            _ => "".to_string(),
+        .map(|event| match (event.code, event.modifiers) {
+            (KeyCode::Char(' '), _) => "<space>".to_string(),
+            (KeyCode::Enter, _) => "<cr>".to_string(),
+            (KeyCode::Char(c), KeyModifiers::NONE) => c.to_string(),
+            (KeyCode::Char(c), KeyModifiers::SHIFT) => format!("<S-{}>", c),
+            (KeyCode::Char(c), KeyModifiers::CONTROL) => format!("<C-{}>", c),
+            (_, _) => "".to_string(),
         })
         .collect::<Vec<String>>()
         .join("")
@@ -83,5 +86,18 @@ mod tests {
         let ending = Span::from("d");
         let expected_line = Line::from(vec![beginning, query_span, ending]);
         assert_eq!(line, expected_line);
+    }
+
+    #[test]
+    fn test_convert_sequence_to_string() {
+        let sequence = vec![
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::SHIFT),
+        ];
+        let expected_string = "<cr>a<C-b><S-c>".to_string();
+        let actual_string = convert_sequence_to_string(sequence);
+        assert_eq!(actual_string, expected_string);
     }
 }


### PR DESCRIPTION
Issue n 4
# Release notes

Introduce tracking of keys presses and display in the active explorer table.

# Pull request overview

This merge allows to track the status of the current sequence of keys pressed. This will be non-empty if the current sequence is `Incomplete` (that is it can result in a `Complete` sequence)

# Outline of changes

- Add a `convert_sequence_to_string` helper function to convert a `Vec` of `KeyEvent`s to a `String`
- Pass the `current_sequence` of the `App` to the `ExplorerManager` when drawing
- Feed the string representation of the `current_sequence` to the `ExplorerTable`'s `draw` function. This necessitates that the `draw` function no longer be implemented based on the trait signature for `ExplorerTable`.

# Quality checks

- [x] Removed all unnecessary imports (as much as reasonably possible)
- [x] Added units tests for the new code
- [x] All unit tests pass
- [x] Added all new shortcuts to `README.md`
- [x] Updated the `README.md` roadmap
- [x] Removed unnecessary debug outputs
- [x] Updated version number
