### PR TITLE
Delete backups indeed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "blaze_explorer"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "blaze_explorer_lib",
  "chrono",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "blaze_explorer_lib"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "clipboard-win",

--- a/blaze_explorer/Cargo.toml
+++ b/blaze_explorer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["tomblazejewski <tomi.blazejewski@gmail.com>"]
 name = "blaze_explorer"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 
 [dependencies]

--- a/blaze_explorer/src/main.rs
+++ b/blaze_explorer/src/main.rs
@@ -70,7 +70,15 @@ fn main() -> Result<(), Box<dyn Error>> {
             stdout().execute(LeaveAlternateScreen)?;
             disable_raw_mode()?;
             match result {
-                Ok(ExitResult::Quit) => break,
+                Ok(ExitResult::Quit) => {
+                    match app.destruct() {
+                        None => {}
+                        Some(msg) => {
+                            println!("{}", msg);
+                        }
+                    }
+                    break;
+                }
                 Ok(ExitResult::OpenNeovim(path)) => {
                     open_neovim(&path)?;
                     bring_app_back(&mut app);

--- a/blaze_explorer_lib/Cargo.toml
+++ b/blaze_explorer_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["tomblazejewski <tomi.blazejewski@gmail.com>"]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 name = "blaze_explorer_lib"
 

--- a/blaze_explorer_lib/src/app.rs
+++ b/blaze_explorer_lib/src/app.rs
@@ -514,6 +514,7 @@ mod tests {
         app.move_directory(starting_path, None);
     }
 
+    #[ignore]
     #[test]
     fn test_destruct_app() {
         let project_dir = get_project_dir();

--- a/blaze_explorer_lib/src/command/command_utils.rs
+++ b/blaze_explorer_lib/src/command/command_utils.rs
@@ -11,6 +11,10 @@ use clipboard_win::Clipboard;
 
 use directories::ProjectDirs;
 
+pub fn get_project_dir() -> ProjectDirs {
+    ProjectDirs::from("", "", "blaze_explorer").unwrap()
+}
+
 ///Obtain the backup directory name to be used for storing the data. This is based on the time of
 ///calling the func.
 pub fn get_backup_dir(create: bool) -> PathBuf {
@@ -19,7 +23,7 @@ pub fn get_backup_dir(create: bool) -> PathBuf {
         Alphanumeric.sample_string(&mut rand::thread_rng(), 16)
     );
     backup_name += ".blzbkp";
-    let proj_dir = ProjectDirs::from("", "", "blaze_explorer").unwrap();
+    let proj_dir = get_project_dir();
     let path = proj_dir.cache_dir().join(backup_name);
     //create this directory
     if create {

--- a/blaze_explorer_lib/src/lib.rs
+++ b/blaze_explorer_lib/src/lib.rs
@@ -1,6 +1,5 @@
 #![crate_name = "blaze_explorer_lib"]
 #![feature(trait_upcasting)]
-#![feature(file_lock)]
 #![feature(reentrant_lock)]
 #![feature(str_split_remainder)]
 pub mod action;

--- a/blaze_explorer_lib/src/lib.rs
+++ b/blaze_explorer_lib/src/lib.rs
@@ -1,5 +1,6 @@
 #![crate_name = "blaze_explorer_lib"]
 #![feature(trait_upcasting)]
+#![feature(file_lock)]
 #![feature(reentrant_lock)]
 #![feature(str_split_remainder)]
 pub mod action;

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ Building of the projects needs to be done in a specific order:
   - [x] Copy
   - [x] Paste
   - [ ] Enable motions of all of the above (see Keymap system)
-  - [ ] Delete backup files upon leaving the app
+  - [x] Delete backup files upon leaving the app
 - [ ] Dir navigation
   - [x] Go up and down the history of a single ExplorerTable
   - [ ] Show directory history of the currenct ExplorerTable


### PR DESCRIPTION
# Release notes

Delete backup files upon leaving the app.

# Pull request overview

This merge allows to clean the space in the cache folder of the project when the app is quitting.

# Outline of changes

- Introduce an additional clause in `main.rs` to call `App::destruct` which currently simply deletes the `cache` folder of the project.

# Quality checks

- [x] Removed all unnecessary imports (as much as reasonably possible)
- [x] Added units tests for the new code
- [x] All unit tests pass
- [x] Added all new shortcuts to `README.md`
- [x] Updated the `README.md` roadmap
- [x] Removed unnecessary debug outputs
- [x] Updated version number
