### PR TITLE
Add an empty file/ copy and rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "blaze_explorer"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "blaze_explorer_lib",
  "chrono",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "blaze_explorer_lib"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "clipboard-win",

--- a/blaze_explorer/Cargo.toml
+++ b/blaze_explorer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["tomblazejewski <tomi.blazejewski@gmail.com>"]
 name = "blaze_explorer"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 
 [dependencies]

--- a/blaze_explorer_lib/Cargo.toml
+++ b/blaze_explorer_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["tomblazejewski <tomi.blazejewski@gmail.com>"]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 name = "blaze_explorer_lib"
 

--- a/blaze_explorer_lib/src/app.rs
+++ b/blaze_explorer_lib/src/app.rs
@@ -294,6 +294,7 @@ impl App {
         if let Some(mut c) = command {
             c.undo(self);
         }
+        //FIXME: this should capture the action returned from the command
     }
     fn redo(&mut self) {
         let path = self.explorer_manager.get_current_path();
@@ -302,6 +303,7 @@ impl App {
         if let Some(mut c) = command {
             c.execute(self);
         }
+        //FIXME: this should capture the action returned from the command
     }
 
     pub fn run_command(&mut self, mut command: Box<dyn Command>) {

--- a/blaze_explorer_lib/src/app_input_machine.rs
+++ b/blaze_explorer_lib/src/app_input_machine.rs
@@ -6,7 +6,7 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::{
     action::{Action, AppAction, CommandAction, ExplorerAction, TextAction},
-    core_features::rename::open_rename_popup,
+    core_features::{add::open_add_popup, rename::open_rename_popup},
     custom_action,
     function_helpers::{pull_current_branch, push_current_branch},
     input_machine::{InputMachine, KeyMapNode, KeyProcessingResult},
@@ -175,6 +175,10 @@ pub fn default_key_map() -> KeyMapNode<Action> {
     root.add_sequence(
         vec![KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE)],
         custom_action!(open_rename_popup),
+    );
+    root.add_sequence(
+        vec![KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE)],
+        custom_action!(open_add_popup),
     );
     root.add_sequence(
         vec![

--- a/blaze_explorer_lib/src/app_input_machine.rs
+++ b/blaze_explorer_lib/src/app_input_machine.rs
@@ -6,7 +6,10 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::{
     action::{Action, AppAction, CommandAction, ExplorerAction, TextAction},
-    core_features::{add::open_add_popup, rename::open_rename_popup},
+    core_features::{
+        add::open_add_popup,
+        rename::{open_copy_rename_popup, open_rename_popup},
+    },
     custom_action,
     function_helpers::{pull_current_branch, push_current_branch},
     input_machine::{InputMachine, KeyMapNode, KeyProcessingResult},
@@ -175,6 +178,10 @@ pub fn default_key_map() -> KeyMapNode<Action> {
     root.add_sequence(
         vec![KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE)],
         custom_action!(open_rename_popup),
+    );
+    root.add_sequence(
+        vec![KeyEvent::new(KeyCode::Char('R'), KeyModifiers::NONE)],
+        custom_action!(open_copy_rename_popup),
     );
     root.add_sequence(
         vec![KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE)],

--- a/blaze_explorer_lib/src/command/command_utils.rs
+++ b/blaze_explorer_lib/src/command/command_utils.rs
@@ -38,7 +38,7 @@ pub fn create_backup_map(files: Vec<PathBuf>) -> HashMap<PathBuf, PathBuf> {
         .map(|file_path| (file_path, get_backup_dir(false)))
         .collect::<HashMap<PathBuf, PathBuf>>()
 }
-pub fn join_paths(path_list: Vec<PathBuf>, new_base: &PathBuf) -> Vec<PathBuf> {
+pub fn join_paths(path_list: Vec<PathBuf>, new_base: &Path) -> Vec<PathBuf> {
     path_list
         .iter()
         .map(|path| {
@@ -178,7 +178,7 @@ mod tests {
             target_dir.path().join("file2.txt"),
             target_dir.path().join("file3.txt"),
         ];
-        let resulting_file_list = join_paths(file_list, &target_dir.path().to_path_buf());
+        let resulting_file_list = join_paths(file_list, &target_dir.path());
         assert_eq!(resulting_file_list, expected_file_list);
         Ok(())
     }

--- a/blaze_explorer_lib/src/command/file_commands.rs
+++ b/blaze_explorer_lib/src/command/file_commands.rs
@@ -275,8 +275,7 @@ pub struct AddDir {
 }
 
 impl AddDir {
-    pub fn new(mut ctx: AppContext, mut name: String) -> Self {
-        let current_dir = ctx.explorer_manager.get_current_path();
+    pub fn new(current_dir: PathBuf, mut name: String) -> Self {
         let mut is_folder = false;
         if name.ends_with('\\') || name.ends_with('/') {
             //remove the last char
@@ -511,7 +510,7 @@ mod tests {
         let root_dir = temp_dir.root_dir.path().to_path_buf();
         let mut app = App::new().unwrap();
         app.explorer_manager.update_path(root_dir.clone(), None);
-        let mut add_dir = AddDir::new(app.get_app_context(), "new_dir/".to_string());
+        let mut add_dir = AddDir::new(root_dir.clone(), "new_dir/".to_string());
         let result = add_dir.execute(&mut app);
         assert!(result.is_none());
         let new_dir = root_dir.join("new_dir");
@@ -531,7 +530,7 @@ mod tests {
         let result_repeat = add_dir.execute(&mut app);
         assert!(result_repeat.is_some());
 
-        let mut add_dir = AddDir::new(app.get_app_context(), "text_file.txt".to_string());
+        let mut add_dir = AddDir::new(root_dir.clone(), "text_file.txt".to_string());
 
         add_dir.execute(&mut app);
         let new_file = root_dir.join("text_file.txt");

--- a/blaze_explorer_lib/src/command/file_commands.rs
+++ b/blaze_explorer_lib/src/command/file_commands.rs
@@ -334,6 +334,9 @@ impl Command for AddDir {
             },
         }
     }
+    fn is_reversible(&self) -> bool {
+        self.reversible
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -511,11 +514,13 @@ mod tests {
         let mut app = App::new().unwrap();
         app.explorer_manager.update_path(root_dir.clone(), None);
         let mut add_dir = AddDir::new(root_dir.clone(), "new_dir/".to_string());
+        assert!(!add_dir.is_reversible());
         let result = add_dir.execute(&mut app);
         assert!(result.is_none());
         let new_dir = root_dir.join("new_dir");
         assert!(new_dir.exists());
         assert!(new_dir.is_dir());
+        assert!(add_dir.is_reversible());
 
         let _ = add_dir.undo(&mut app);
         assert!(!new_dir.exists());
@@ -532,10 +537,12 @@ mod tests {
 
         let mut add_dir = AddDir::new(root_dir.clone(), "text_file.txt".to_string());
 
+        assert!(!add_dir.is_reversible());
         add_dir.execute(&mut app);
         let new_file = root_dir.join("text_file.txt");
         assert!(new_file.exists());
         assert!(new_file.is_file());
+        assert!(add_dir.is_reversible());
 
         let _ = add_dir.undo(&mut app);
         assert!(!new_file.exists());

--- a/blaze_explorer_lib/src/command/file_commands.rs
+++ b/blaze_explorer_lib/src/command/file_commands.rs
@@ -7,6 +7,7 @@ use super::command_utils::{create_backup_map, get_backup_dir, join_paths};
 
 use crate::action::{Action, AppAction};
 use std::fmt::Debug;
+use std::fs::File;
 use std::io;
 use std::{collections::HashMap, path::PathBuf};
 use std::{fmt, fs};
@@ -266,12 +267,84 @@ impl Command for PasteFromClipboard {
     }
 }
 
+#[derive(Clone, PartialEq, Debug)]
+pub struct AddDir {
+    new_dir: PathBuf,
+    is_folder: bool,
+    reversible: bool,
+}
+
+impl AddDir {
+    pub fn new(mut ctx: AppContext, mut name: String) -> Self {
+        let current_dir = ctx.explorer_manager.get_current_path();
+        let mut is_folder = false;
+        if name.ends_with('\\') || name.ends_with('/') {
+            //remove the last char
+            name = name[0..name.len() - 1].to_string();
+            is_folder = true;
+        }
+        Self {
+            new_dir: current_dir.join(name),
+            is_folder,
+            reversible: false,
+        }
+    }
+}
+
+impl Command for AddDir {
+    fn execute(&mut self, app: &mut App) -> Option<Action> {
+        match self.is_folder {
+            true => match fs::create_dir(&self.new_dir) {
+                Ok(()) => {
+                    self.reversible = true;
+                    None
+                }
+                Err(e) => Some(Action::AppAct(AppAction::DisplayMessage(format!(
+                    "Error while creating directory: {:?}",
+                    e
+                )))),
+            },
+            false => match File::create(&self.new_dir) {
+                Ok(file) => {
+                    self.reversible = true;
+                    None
+                }
+                Err(e) => Some(Action::AppAct(AppAction::DisplayMessage(format!(
+                    "Error while creating directory: {:?}",
+                    e
+                )))),
+            },
+        }
+    }
+
+    fn undo(&mut self, _app: &mut App) -> Option<Action> {
+        match self.is_folder {
+            true => match fs::remove_dir_all(&self.new_dir) {
+                Ok(()) => None,
+                Err(e) => Some(Action::AppAct(AppAction::DisplayMessage(format!(
+                    "Error while removing directory: {:?}",
+                    e
+                )))),
+            },
+            false => match fs::remove_file(&self.new_dir) {
+                Ok(()) => None,
+                Err(e) => Some(Action::AppAct(AppAction::DisplayMessage(format!(
+                    "Error while removing directory: {:?}",
+                    e
+                )))),
+            },
+        }
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::env;
 
-    use crate::{action::ExplorerAction, testing_utils::create_testing_folder};
+    use crate::{
+        action::ExplorerAction,
+        testing_utils::{create_custom_testing_folder, create_testing_folder},
+    };
     #[test]
     fn test_rename_active() {
         let mut app = App::new().unwrap();
@@ -430,5 +503,42 @@ mod tests {
             assert!(path.exists(), "File {:?} does not exist", path);
         }
         app.move_directory(starting_path, None);
+    }
+
+    #[test]
+    fn test_add_dir() {
+        let temp_dir = create_custom_testing_folder(Vec::new()).unwrap();
+        let root_dir = temp_dir.root_dir.path().to_path_buf();
+        let mut app = App::new().unwrap();
+        app.explorer_manager.update_path(root_dir.clone(), None);
+        let mut add_dir = AddDir::new(app.get_app_context(), "new_dir/".to_string());
+        let result = add_dir.execute(&mut app);
+        assert!(result.is_none());
+        let new_dir = root_dir.join("new_dir");
+        assert!(new_dir.exists());
+        assert!(new_dir.is_dir());
+
+        let _ = add_dir.undo(&mut app);
+        assert!(!new_dir.exists());
+
+        //test creating twice
+        let result = add_dir.execute(&mut app);
+        assert!(result.is_none());
+        let new_dir = root_dir.join("new_dir");
+        assert!(new_dir.exists());
+        assert!(new_dir.is_dir());
+
+        let result_repeat = add_dir.execute(&mut app);
+        assert!(result_repeat.is_some());
+
+        let mut add_dir = AddDir::new(app.get_app_context(), "text_file.txt".to_string());
+
+        add_dir.execute(&mut app);
+        let new_file = root_dir.join("text_file.txt");
+        assert!(new_file.exists());
+        assert!(new_file.is_file());
+
+        let _ = add_dir.undo(&mut app);
+        assert!(!new_file.exists());
     }
 }

--- a/blaze_explorer_lib/src/core_features.rs
+++ b/blaze_explorer_lib/src/core_features.rs
@@ -1,1 +1,2 @@
+pub mod add;
 pub mod rename;

--- a/blaze_explorer_lib/src/core_features/add.rs
+++ b/blaze_explorer_lib/src/core_features/add.rs
@@ -1,0 +1,164 @@
+use crate::{command::file_commands::AddDir, plugin::plugin_action::PluginAction};
+use std::{collections::HashMap, path::PathBuf};
+
+use color_eyre::eyre::Result;
+use ratatui::{
+    Frame,
+    crossterm::event::KeyEvent,
+    layout::{Constraint, Rect},
+    widgets::{Block, Borders, Clear, Paragraph},
+};
+
+use crate::{
+    action::Action,
+    app::App,
+    create_plugin_action,
+    input_machine::input_machine_helpers::convert_str_to_events,
+    line_entry::LineEntry,
+    mode::Mode,
+    plugin::{
+        plugin_commands::{PluginConfirmResult, PluginDropSearchChar, PluginQuit},
+        plugin_helpers::get_push_on_char_action,
+        plugin_popup::PluginPopUp,
+    },
+    query::Query,
+    tools::center_rect,
+};
+pub fn open_add_popup(app: &mut App) -> Option<Action> {
+    let mut ctx = app.get_app_context();
+    let dir = match ctx.explorer_manager.select_directory() {
+        Some(dir) => dir.clone(),
+        //Unable to set the selected to None
+        None => {
+            panic!("Could not get the starting directory from the explorer manager")
+        }
+    };
+    let popup = Box::new(AddPopUp::new(dir));
+    app.attach_popup(popup);
+
+    None
+}
+
+fn get_add_popup_keymap() -> HashMap<(Mode, Vec<KeyEvent>), Action> {
+    let mut keymap = HashMap::new();
+    keymap.insert(
+        (Mode::PopUp, convert_str_to_events("<Esc>")),
+        create_plugin_action!(PluginQuit),
+    );
+    keymap.insert(
+        (Mode::PopUp, convert_str_to_events("<BS>")),
+        create_plugin_action!(PluginDropSearchChar),
+    );
+    keymap.insert(
+        (Mode::PopUp, convert_str_to_events("<CR>")),
+        create_plugin_action!(PluginConfirmResult),
+    );
+    keymap
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AddPopUp {
+    pub should_quit: bool,
+    query: Query,
+    current_dir: PathBuf,
+    keymap: HashMap<(Mode, Vec<KeyEvent>), Action>,
+}
+
+impl AddPopUp {
+    pub fn new(dir: PathBuf) -> Self {
+        let query = Query::new("".to_string(), "".to_string());
+        Self {
+            should_quit: false,
+            query,
+            current_dir: dir,
+            keymap: get_add_popup_keymap(),
+        }
+    }
+}
+
+impl PluginPopUp for AddPopUp {
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        let query_area = center_rect(
+            frame.size(),
+            Constraint::Percentage(50),
+            Constraint::Length(3),
+        );
+        let title = "Add dir";
+        let query_block = Block::default().borders(Borders::ALL).title(title);
+        let rename_field_output = self.get_search_query();
+        let query_paragraph = Paragraph::new(rename_field_output);
+        let query_paragraph = query_paragraph.block(query_block);
+
+        frame.render_widget(Clear, query_area);
+        frame.render_widget(query_paragraph, query_area);
+
+        Ok(())
+    }
+
+    fn push_search_char(&mut self, ch: char) -> Option<Action> {
+        self.query.append_char(ch);
+        None
+    }
+
+    fn drop_search_char(&mut self) -> Option<Action> {
+        self.query.drop_char();
+        None
+    }
+
+    fn quit(&mut self) {
+        self.should_quit = true;
+    }
+
+    fn should_quit(&self) -> bool {
+        self.should_quit
+    }
+
+    fn erase_text(&mut self) -> Option<Action> {
+        self.query.clear_contents();
+        None
+    }
+
+    fn get_search_query(&self) -> String {
+        self.query.get_contents()
+    }
+
+    fn display_details(&self) -> String {
+        "Add dir".to_string()
+    }
+
+    fn get_own_keymap(&self) -> HashMap<(Mode, Vec<KeyEvent>), Action> {
+        self.keymap.clone()
+    }
+
+    fn get_default_action(&self) -> Box<fn(KeyEvent) -> Option<Action>> {
+        Box::new(get_push_on_char_action)
+    }
+    fn confirm_result(&mut self) -> Option<Action> {
+        self.quit();
+        Some(create_plugin_action!(
+            AddDir,
+            self.current_dir.clone(),
+            self.get_search_query()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+
+    use crate::testing_utils::create_custom_testing_folder;
+
+    use super::*;
+    #[test]
+    fn test_add_popup() {
+        let mut app = App::new().unwrap();
+        let test_folder = create_custom_testing_folder(vec!["test_folder/"]).unwrap();
+        let root_dir = test_folder.root_dir.path().to_path_buf();
+        app.update_path(root_dir.clone(), Some("test_folder".to_string()));
+        open_add_popup(&mut app);
+        let expected_popup: Box<dyn PluginPopUp> = Box::new(AddPopUp::new(root_dir.clone()));
+        let actual_popup = app.popup.unwrap();
+        assert!(expected_popup == actual_popup.clone());
+    }
+}

--- a/blaze_explorer_lib/src/core_features/add.rs
+++ b/blaze_explorer_lib/src/core_features/add.rs
@@ -26,13 +26,7 @@ use crate::{
 };
 pub fn open_add_popup(app: &mut App) -> Option<Action> {
     let mut ctx = app.get_app_context();
-    let dir = match ctx.explorer_manager.select_directory() {
-        Some(dir) => dir.clone(),
-        //Unable to set the selected to None
-        None => {
-            panic!("Could not get the starting directory from the explorer manager")
-        }
-    };
+    let dir = ctx.explorer_manager.get_current_path();
     let popup = Box::new(AddPopUp::new(dir));
     app.attach_popup(popup);
 

--- a/blaze_explorer_lib/src/core_features/add.rs
+++ b/blaze_explorer_lib/src/core_features/add.rs
@@ -1,4 +1,7 @@
-use crate::{command::file_commands::AddDir, plugin::plugin_action::PluginAction};
+use crate::{
+    command::file_commands::AddDir,
+    plugin::{base_popup::get_default_popup_keymap, plugin_action::PluginAction},
+};
 use std::{collections::HashMap, path::PathBuf};
 
 use color_eyre::eyre::Result;
@@ -33,23 +36,6 @@ pub fn open_add_popup(app: &mut App) -> Option<Action> {
     None
 }
 
-fn get_add_popup_keymap() -> HashMap<(Mode, Vec<KeyEvent>), Action> {
-    let mut keymap = HashMap::new();
-    keymap.insert(
-        (Mode::PopUp, convert_str_to_events("<Esc>")),
-        create_plugin_action!(PluginQuit),
-    );
-    keymap.insert(
-        (Mode::PopUp, convert_str_to_events("<BS>")),
-        create_plugin_action!(PluginDropSearchChar),
-    );
-    keymap.insert(
-        (Mode::PopUp, convert_str_to_events("<CR>")),
-        create_plugin_action!(PluginConfirmResult),
-    );
-    keymap
-}
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct AddPopUp {
     pub should_quit: bool,
@@ -65,7 +51,7 @@ impl AddPopUp {
             should_quit: false,
             query,
             current_dir: dir,
-            keymap: get_add_popup_keymap(),
+            keymap: get_default_popup_keymap(),
         }
     }
 }

--- a/blaze_explorer_lib/src/core_features/add.rs
+++ b/blaze_explorer_lib/src/core_features/add.rs
@@ -139,7 +139,6 @@ impl PluginPopUp for AddPopUp {
 
 #[cfg(test)]
 mod tests {
-    use std::env;
 
     use crate::testing_utils::create_custom_testing_folder;
 

--- a/blaze_explorer_lib/src/core_features/add.rs
+++ b/blaze_explorer_lib/src/core_features/add.rs
@@ -16,14 +16,9 @@ use crate::{
     action::Action,
     app::App,
     create_plugin_action,
-    input_machine::input_machine_helpers::convert_str_to_events,
     line_entry::LineEntry,
     mode::Mode,
-    plugin::{
-        plugin_commands::{PluginConfirmResult, PluginDropSearchChar, PluginQuit},
-        plugin_helpers::get_push_on_char_action,
-        plugin_popup::PluginPopUp,
-    },
+    plugin::{plugin_helpers::get_push_on_char_action, plugin_popup::PluginPopUp},
     query::Query,
     tools::center_rect,
 };
@@ -36,6 +31,7 @@ pub fn open_add_popup(app: &mut App) -> Option<Action> {
     None
 }
 
+/// Popup for adding a new directory
 #[derive(Debug, Clone, PartialEq)]
 pub struct AddPopUp {
     pub should_quit: bool,

--- a/blaze_explorer_lib/src/core_features/rename.rs
+++ b/blaze_explorer_lib/src/core_features/rename.rs
@@ -1,13 +1,10 @@
-use crate::plugin::plugin_action::PluginAction;
+use crate::plugin::{
+    base_popup::{BasePopUp, GenericPopUp, Popupbehaviour},
+    plugin_action::PluginAction,
+};
 use std::{collections::HashMap, path::PathBuf};
 
-use color_eyre::eyre::Result;
-use ratatui::{
-    Frame,
-    crossterm::event::KeyEvent,
-    layout::{Constraint, Rect},
-    widgets::{Block, Borders, Clear, Paragraph},
-};
+use ratatui::crossterm::event::KeyEvent;
 
 use crate::{
     action::Action,
@@ -15,28 +12,46 @@ use crate::{
     command::file_commands::RenameActive,
     create_plugin_action,
     input_machine::input_machine_helpers::convert_str_to_events,
-    line_entry::LineEntry,
     mode::Mode,
     plugin::{
         plugin_commands::{PluginConfirmResult, PluginDropSearchChar, PluginQuit},
-        plugin_helpers::get_push_on_char_action,
         plugin_popup::PluginPopUp,
     },
     query::Query,
-    tools::center_rect,
 };
 pub fn open_rename_popup(app: &mut App) -> Option<Action> {
     let mut ctx = app.get_app_context();
-    let dir = match ctx.explorer_manager.select_directory() {
-        Some(dir) => dir.clone(),
-        //Unable to set the selected to None
-        None => {
-            panic!("Could not get the starting directory from the explorer manager")
-        }
-    };
-    let popup = Box::new(RenamePopUp::new(dir));
-    app.attach_popup(popup);
+    let dir = ctx.explorer_manager.select_directory().unwrap().clone();
 
+    let initial_name = dir
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .split('.')
+        .next()
+        .unwrap()
+        .to_string();
+    let extension = dir
+        .extension()
+        .map_or("".to_string(), |e| format!(".{}", e.to_str().unwrap()));
+
+    let query = Query::new_with_contents("".to_string(), initial_name.clone(), extension.clone());
+    let keymap = get_rename_popup_keymap();
+
+    let base = BasePopUp {
+        should_quit: false,
+        query,
+        keymap,
+    };
+
+    let behaviour = RenameBehaviour {
+        initial_path: dir,
+        initial_name,
+        extension,
+    };
+
+    app.attach_popup(Box::new(GenericPopUp { base, behaviour }));
     None
 }
 
@@ -58,123 +73,57 @@ fn get_rename_popup_keymap() -> HashMap<(Mode, Vec<KeyEvent>), Action> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct RenamePopUp {
-    pub should_quit: bool,
-    query: Query,
+struct RenameBehaviour {
     initial_path: PathBuf,
     initial_name: String,
     extension: String,
-    keymap: HashMap<(Mode, Vec<KeyEvent>), Action>,
 }
 
-impl RenamePopUp {
-    pub fn new(dir: PathBuf) -> Self {
-        let extension = match dir.extension() {
-            Some(path) => format!(".{}", path.to_str().unwrap()),
-            None => "".to_string(),
-        };
-        let initial_name = dir.file_name().unwrap().to_str().unwrap().to_string();
-        let initial_name_without_extension = initial_name.split(".").next().unwrap();
-        let query = Query::new_with_contents(
-            "".to_string(),
-            initial_name_without_extension.to_string(),
-            extension.clone(),
-        );
-        Self {
-            should_quit: false,
-            query,
-            initial_path: dir,
-            initial_name,
-            extension,
-            keymap: get_rename_popup_keymap(),
-        }
-    }
-}
-
-impl PluginPopUp for RenamePopUp {
-    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
-        let query_area = center_rect(
-            frame.size(),
-            Constraint::Percentage(50),
-            Constraint::Length(3),
-        );
-        let title = format!("Rename {}", self.initial_name);
-        let query_block = Block::default().borders(Borders::ALL).title(title);
-        let rename_field_output = self.get_search_query();
-        let query_paragraph = Paragraph::new(rename_field_output);
-        let query_paragraph = query_paragraph.block(query_block);
-
-        frame.render_widget(Clear, query_area);
-        frame.render_widget(query_paragraph, query_area);
-
-        Ok(())
+impl Popupbehaviour for RenameBehaviour {
+    fn popup_title(&self) -> String {
+        format!("Rename {}", self.initial_name)
     }
 
-    fn push_search_char(&mut self, ch: char) -> Option<Action> {
-        self.query.append_char(ch);
-        None
-    }
-
-    fn drop_search_char(&mut self) -> Option<Action> {
-        self.query.drop_char();
-        None
-    }
-
-    fn quit(&mut self) {
-        self.should_quit = true;
-    }
-
-    fn should_quit(&self) -> bool {
-        self.should_quit
-    }
-
-    fn erase_text(&mut self) -> Option<Action> {
-        self.query.clear_contents();
-        None
-    }
-
-    fn get_search_query(&self) -> String {
-        self.query.get_contents()
+    fn confirm_action(&self, query: String) -> Action {
+        create_plugin_action!(RenameActive, self.initial_path.clone(), query)
     }
 
     fn display_details(&self) -> String {
         format!("Rename {}{}", self.initial_name, self.extension)
     }
-
-    fn get_own_keymap(&self) -> HashMap<(Mode, Vec<KeyEvent>), Action> {
-        self.keymap.clone()
-    }
-
-    fn get_default_action(&self) -> Box<fn(KeyEvent) -> Option<Action>> {
-        Box::new(get_push_on_char_action)
-    }
-    fn confirm_result(&mut self) -> Option<Action> {
-        self.quit();
-        Some(create_plugin_action!(
-            RenameActive,
-            self.initial_path.clone(),
-            self.get_search_query()
-        ))
-    }
 }
-
 #[cfg(test)]
 mod tests {
-    use std::env;
 
     use crate::testing_utils::create_custom_testing_folder;
 
     use super::*;
+
     #[test]
     fn test_open_rename_popup() {
+        let test_folder = create_custom_testing_folder(vec!["file.txt"]).unwrap();
+        let initial_path = test_folder.root_dir.path().join("file.txt");
+
         let mut app = App::new().unwrap();
-        let test_folder = create_custom_testing_folder(vec!["folder_1/"]).unwrap();
-        let root_dir = test_folder.root_dir.path().to_path_buf();
-        app.update_path(root_dir.clone(), Some("folder_1".to_string()));
-        open_rename_popup(&mut app);
-        let expected_dir = root_dir.join("folder_1");
-        let expected_popup: Box<dyn PluginPopUp> = Box::new(RenamePopUp::new(expected_dir));
-        let actual_popup = app.popup.unwrap();
-        assert!(expected_popup == actual_popup.clone());
+        app.explorer_manager.show_in_folder(initial_path.clone());
+        let action = open_rename_popup(&mut app);
+
+        let query = Query::new_with_contents("".into(), "file".into(), ".txt".into());
+        let keymap = get_rename_popup_keymap();
+        let behaviour = RenameBehaviour {
+            initial_path: initial_path.clone(),
+            initial_name: "file".into(),
+            extension: ".txt".into(),
+        };
+        let base = BasePopUp {
+            should_quit: false,
+            query,
+            keymap,
+        };
+        let expected = Box::new(GenericPopUp { base, behaviour }) as Box<dyn PluginPopUp>;
+        let attached_popup = app.popup.unwrap();
+
+        assert!(attached_popup == expected);
+        assert!(action.is_none());
     }
 }

--- a/blaze_explorer_lib/src/core_features/rename.rs
+++ b/blaze_explorer_lib/src/core_features/rename.rs
@@ -162,16 +162,17 @@ impl PluginPopUp for RenamePopUp {
 mod tests {
     use std::env;
 
+    use crate::testing_utils::create_custom_testing_folder;
+
     use super::*;
     #[test]
     fn test_open_rename_popup() {
         let mut app = App::new().unwrap();
-        let current_path = env::current_dir().unwrap();
-        let test_path = current_path.join("../tests");
-        app.update_path(test_path.clone(), Some("folder_1".to_string()));
+        let test_folder = create_custom_testing_folder(vec!["folder_1/"]).unwrap();
+        let root_dir = test_folder.root_dir.path().to_path_buf();
+        app.update_path(root_dir.clone(), Some("folder_1".to_string()));
         open_rename_popup(&mut app);
-        let expected_dir = test_path.join("folder_1");
-        let expected_popup: Box<dyn PluginPopUp> = Box::new(RenamePopUp::new(expected_dir));
+        let expected_popup: Box<dyn PluginPopUp> = Box::new(RenamePopUp::new(root_dir.clone()));
         let actual_popup = app.popup.unwrap();
         assert!(expected_popup == actual_popup.clone());
     }

--- a/blaze_explorer_lib/src/core_features/rename.rs
+++ b/blaze_explorer_lib/src/core_features/rename.rs
@@ -1,5 +1,5 @@
 use crate::plugin::{
-    base_popup::{BasePopUp, GenericPopUp, Popupbehaviour},
+    base_popup::{BasePopUp, GenericPopUp, Popupbehaviour, get_default_popup_keymap},
     plugin_action::PluginAction,
 };
 use std::{collections::HashMap, path::PathBuf};
@@ -34,7 +34,7 @@ pub fn open_rename_popup(app: &mut App) -> Option<Action> {
         .map_or("".to_string(), |e| format!(".{}", e.to_str().unwrap()));
 
     let query = Query::new_with_contents("".to_string(), initial_name.clone(), extension.clone());
-    let keymap = get_rename_popup_keymap();
+    let keymap = get_default_popup_keymap();
 
     let base = BasePopUp {
         should_quit: false,
@@ -50,23 +50,6 @@ pub fn open_rename_popup(app: &mut App) -> Option<Action> {
 
     app.attach_popup(Box::new(GenericPopUp { base, behaviour }));
     None
-}
-
-fn get_rename_popup_keymap() -> HashMap<(Mode, Vec<KeyEvent>), Action> {
-    let mut keymap = HashMap::new();
-    keymap.insert(
-        (Mode::PopUp, convert_str_to_events("<Esc>")),
-        create_plugin_action!(PluginQuit),
-    );
-    keymap.insert(
-        (Mode::PopUp, convert_str_to_events("<BS>")),
-        create_plugin_action!(PluginDropSearchChar),
-    );
-    keymap.insert(
-        (Mode::PopUp, convert_str_to_events("<CR>")),
-        create_plugin_action!(PluginConfirmResult),
-    );
-    keymap
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -92,7 +75,10 @@ impl Popupbehaviour for RenameBehaviour {
 #[cfg(test)]
 mod tests {
 
-    use crate::{plugin::plugin_popup::PluginPopUp, testing_utils::create_custom_testing_folder};
+    use crate::{
+        plugin::{base_popup::get_default_popup_keymap, plugin_popup::PluginPopUp},
+        testing_utils::create_custom_testing_folder,
+    };
 
     use super::*;
 
@@ -106,7 +92,7 @@ mod tests {
         let action = open_rename_popup(&mut app);
 
         let query = Query::new_with_contents("".into(), "file".into(), ".txt".into());
-        let keymap = get_rename_popup_keymap();
+        let keymap = get_default_popup_keymap();
         let behaviour = RenameBehaviour {
             initial_path: initial_path.clone(),
             initial_name: "file".into(),

--- a/blaze_explorer_lib/src/core_features/rename.rs
+++ b/blaze_explorer_lib/src/core_features/rename.rs
@@ -13,10 +13,7 @@ use crate::{
     create_plugin_action,
     input_machine::input_machine_helpers::convert_str_to_events,
     mode::Mode,
-    plugin::{
-        plugin_commands::{PluginConfirmResult, PluginDropSearchChar, PluginQuit},
-        plugin_popup::PluginPopUp,
-    },
+    plugin::plugin_commands::{PluginConfirmResult, PluginDropSearchChar, PluginQuit},
     query::Query,
 };
 pub fn open_rename_popup(app: &mut App) -> Option<Action> {
@@ -95,7 +92,7 @@ impl Popupbehaviour for RenameBehaviour {
 #[cfg(test)]
 mod tests {
 
-    use crate::testing_utils::create_custom_testing_folder;
+    use crate::{plugin::plugin_popup::PluginPopUp, testing_utils::create_custom_testing_folder};
 
     use super::*;
 

--- a/blaze_explorer_lib/src/core_features/rename.rs
+++ b/blaze_explorer_lib/src/core_features/rename.rs
@@ -1,22 +1,20 @@
-use crate::plugin::{
-    base_popup::{BasePopUp, GenericPopUp, Popupbehaviour, get_default_popup_keymap},
-    plugin_action::PluginAction,
+use crate::{
+    command::file_commands::CopyRenameActive,
+    plugin::{
+        base_popup::{BasePopUp, GenericPopUp, Popupbehaviour, get_default_popup_keymap},
+        plugin_action::PluginAction,
+    },
 };
 use std::{collections::HashMap, path::PathBuf};
 
 use ratatui::crossterm::event::KeyEvent;
 
 use crate::{
-    action::Action,
-    app::App,
-    command::file_commands::RenameActive,
-    create_plugin_action,
-    input_machine::input_machine_helpers::convert_str_to_events,
-    mode::Mode,
-    plugin::plugin_commands::{PluginConfirmResult, PluginDropSearchChar, PluginQuit},
+    action::Action, app::App, command::file_commands::RenameActive, create_plugin_action,
     query::Query,
 };
-pub fn open_rename_popup(app: &mut App) -> Option<Action> {
+
+pub fn open_generic_rename_popup(app: &mut App, copy: bool) -> Option<Action> {
     let mut ctx = app.get_app_context();
     let dir = ctx.explorer_manager.select_directory().unwrap().clone();
 
@@ -46,10 +44,18 @@ pub fn open_rename_popup(app: &mut App) -> Option<Action> {
         initial_path: dir,
         initial_name,
         extension,
+        copy,
     };
 
     app.attach_popup(Box::new(GenericPopUp { base, behaviour }));
     None
+}
+pub fn open_rename_popup(app: &mut App) -> Option<Action> {
+    open_generic_rename_popup(app, false)
+}
+
+pub fn open_copy_rename_popup(app: &mut App) -> Option<Action> {
+    open_generic_rename_popup(app, true)
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -57,6 +63,7 @@ struct RenameBehaviour {
     initial_path: PathBuf,
     initial_name: String,
     extension: String,
+    copy: bool,
 }
 
 impl Popupbehaviour for RenameBehaviour {
@@ -65,7 +72,10 @@ impl Popupbehaviour for RenameBehaviour {
     }
 
     fn confirm_action(&self, query: String) -> Action {
-        create_plugin_action!(RenameActive, self.initial_path.clone(), query)
+        match self.copy {
+            true => create_plugin_action!(CopyRenameActive, self.initial_path.clone(), query),
+            false => create_plugin_action!(RenameActive, self.initial_path.clone(), query),
+        }
     }
 
     fn display_details(&self) -> String {
@@ -97,6 +107,35 @@ mod tests {
             initial_path: initial_path.clone(),
             initial_name: "file".into(),
             extension: ".txt".into(),
+            copy: false,
+        };
+        let base = BasePopUp {
+            should_quit: false,
+            query,
+            keymap,
+        };
+        let expected = Box::new(GenericPopUp { base, behaviour }) as Box<dyn PluginPopUp>;
+        let attached_popup = app.popup.unwrap();
+
+        assert!(attached_popup == expected);
+        assert!(action.is_none());
+    }
+    #[test]
+    fn test_open_copy_rename_popup() {
+        let test_folder = create_custom_testing_folder(vec!["file.txt"]).unwrap();
+        let initial_path = test_folder.root_dir.path().join("file.txt");
+
+        let mut app = App::new().unwrap();
+        app.explorer_manager.show_in_folder(initial_path.clone());
+        let action = open_copy_rename_popup(&mut app);
+
+        let query = Query::new_with_contents("".into(), "file".into(), ".txt".into());
+        let keymap = get_default_popup_keymap();
+        let behaviour = RenameBehaviour {
+            initial_path: initial_path.clone(),
+            initial_name: "file".into(),
+            extension: ".txt".into(),
+            copy: true,
         };
         let base = BasePopUp {
             should_quit: false,

--- a/blaze_explorer_lib/src/core_features/rename.rs
+++ b/blaze_explorer_lib/src/core_features/rename.rs
@@ -5,15 +5,23 @@ use crate::{
         plugin_action::PluginAction,
     },
 };
-use std::{collections::HashMap, path::PathBuf};
-
-use ratatui::crossterm::event::KeyEvent;
+use std::path::PathBuf;
 
 use crate::{
     action::Action, app::App, command::file_commands::RenameActive, create_plugin_action,
     query::Query,
 };
 
+/// Open a popup for renaming a file
+///
+/// # Arguments
+///
+/// * `app` - The app to attach the popup to
+/// * `copy` - Whether to copy the file or rename in place
+///
+/// # Returns
+///
+/// * `Option<Action>`
 pub fn open_generic_rename_popup(app: &mut App, copy: bool) -> Option<Action> {
     let mut ctx = app.get_app_context();
     let dir = ctx.explorer_manager.select_directory().unwrap().clone();
@@ -50,14 +58,18 @@ pub fn open_generic_rename_popup(app: &mut App, copy: bool) -> Option<Action> {
     app.attach_popup(Box::new(GenericPopUp { base, behaviour }));
     None
 }
+
+/// Open a popup for renaming a file. Renames in place
 pub fn open_rename_popup(app: &mut App) -> Option<Action> {
     open_generic_rename_popup(app, false)
 }
 
+/// Open a popup for renaming a file. Renames a new copy
 pub fn open_copy_rename_popup(app: &mut App) -> Option<Action> {
     open_generic_rename_popup(app, true)
 }
 
+/// Behaviour for the rename popup
 #[derive(Debug, Clone, PartialEq)]
 struct RenameBehaviour {
     initial_path: PathBuf,

--- a/blaze_explorer_lib/src/core_features/rename.rs
+++ b/blaze_explorer_lib/src/core_features/rename.rs
@@ -172,7 +172,8 @@ mod tests {
         let root_dir = test_folder.root_dir.path().to_path_buf();
         app.update_path(root_dir.clone(), Some("folder_1".to_string()));
         open_rename_popup(&mut app);
-        let expected_popup: Box<dyn PluginPopUp> = Box::new(RenamePopUp::new(root_dir.clone()));
+        let expected_dir = root_dir.join("folder_1");
+        let expected_popup: Box<dyn PluginPopUp> = Box::new(RenamePopUp::new(expected_dir));
         let actual_popup = app.popup.unwrap();
         assert!(expected_popup == actual_popup.clone());
     }

--- a/blaze_explorer_lib/src/plugin.rs
+++ b/blaze_explorer_lib/src/plugin.rs
@@ -6,11 +6,11 @@ use ratatui::crossterm::event::KeyEvent;
 
 use crate::{action::Action, app::App};
 
+pub mod base_popup;
 pub mod plugin_action;
 pub mod plugin_commands;
 pub mod plugin_helpers;
 pub mod plugin_popup;
-
 fn build_keymap(
     functionality_map: HashMap<String, Action>,
     bindings_map: HashMap<(Mode, Vec<KeyEvent>), String>,

--- a/blaze_explorer_lib/src/plugin/base_popup.rs
+++ b/blaze_explorer_lib/src/plugin/base_popup.rs
@@ -1,0 +1,91 @@
+use std::{collections::HashMap, fmt::Debug};
+
+use color_eyre::eyre::Result;
+use ratatui::{Frame, crossterm::event::KeyEvent, layout::Rect};
+
+use crate::{action::Action, line_entry::LineEntry, mode::Mode, query::Query};
+
+use super::plugin_popup::PluginPopUp;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BasePopUp {
+    pub should_quit: bool,
+    pub query: Query,
+    pub keymap: HashMap<(Mode, Vec<KeyEvent>), Action>,
+}
+
+pub trait PopupBehavior {
+    fn popup_title(&self) -> String;
+    fn confirm_action(&self, query: String) -> Action;
+    fn display_details(&self) -> String;
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GenericPopUp<T: PopupBehavior> {
+    pub base: BasePopUp,
+    pub behavior: T,
+}
+
+impl<T: PopupBehavior + Clone + Debug + PartialEq + 'static> PluginPopUp for GenericPopUp<T> {
+    fn draw(&mut self, frame: &mut Frame, area: Rect) -> Result<()> {
+        let query_area = crate::tools::center_rect(
+            frame.size(),
+            ratatui::layout::Constraint::Percentage(50),
+            ratatui::layout::Constraint::Length(3),
+        );
+        let title = self.behavior.popup_title();
+        let query_block = ratatui::widgets::Block::default()
+            .borders(ratatui::widgets::Borders::ALL)
+            .title(title);
+        let query_paragraph =
+            ratatui::widgets::Paragraph::new(self.base.query.get_contents()).block(query_block);
+
+        frame.render_widget(ratatui::widgets::Clear, query_area);
+        frame.render_widget(query_paragraph, query_area);
+        Ok(())
+    }
+
+    fn push_search_char(&mut self, ch: char) -> Option<Action> {
+        self.base.query.append_char(ch);
+        None
+    }
+
+    fn drop_search_char(&mut self) -> Option<Action> {
+        self.base.query.drop_char();
+        None
+    }
+
+    fn quit(&mut self) {
+        self.base.should_quit = true;
+    }
+
+    fn should_quit(&self) -> bool {
+        self.base.should_quit
+    }
+
+    fn erase_text(&mut self) -> Option<Action> {
+        self.base.query.clear_contents();
+        None
+    }
+
+    fn get_search_query(&self) -> String {
+        self.base.query.get_contents()
+    }
+
+    fn display_details(&self) -> String {
+        self.behavior.display_details()
+    }
+
+    fn get_own_keymap(&self) -> HashMap<(Mode, Vec<KeyEvent>), Action> {
+        self.base.keymap.clone()
+    }
+
+    fn get_default_action(&self) -> Box<fn(KeyEvent) -> Option<Action>> {
+        Box::new(crate::plugin::plugin_helpers::get_push_on_char_action)
+    }
+
+    fn confirm_result(&mut self) -> Option<Action> {
+        self.quit();
+        Some(self.behavior.confirm_action(self.get_search_query()))
+    }
+}

--- a/blaze_explorer_lib/src/plugin/base_popup.rs
+++ b/blaze_explorer_lib/src/plugin/base_popup.rs
@@ -8,9 +8,35 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
 };
 
-use crate::{action::Action, line_entry::LineEntry, mode::Mode, query::Query, tools::center_rect};
+use crate::{
+    action::Action, create_plugin_action,
+    input_machine::input_machine_helpers::convert_str_to_events, line_entry::LineEntry, mode::Mode,
+    query::Query, tools::center_rect,
+};
 
-use super::{plugin_helpers::get_push_on_char_action, plugin_popup::PluginPopUp};
+use super::{
+    plugin_action::PluginAction,
+    plugin_commands::{PluginConfirmResult, PluginDropSearchChar, PluginQuit},
+    plugin_helpers::get_push_on_char_action,
+    plugin_popup::PluginPopUp,
+};
+
+pub fn get_default_popup_keymap() -> HashMap<(Mode, Vec<KeyEvent>), Action> {
+    let mut keymap = HashMap::new();
+    keymap.insert(
+        (Mode::PopUp, convert_str_to_events("<Esc>")),
+        create_plugin_action!(PluginQuit),
+    );
+    keymap.insert(
+        (Mode::PopUp, convert_str_to_events("<BS>")),
+        create_plugin_action!(PluginDropSearchChar),
+    );
+    keymap.insert(
+        (Mode::PopUp, convert_str_to_events("<CR>")),
+        create_plugin_action!(PluginConfirmResult),
+    );
+    keymap
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct BasePopUp {

--- a/blaze_explorer_lib/src/plugin/base_popup.rs
+++ b/blaze_explorer_lib/src/plugin/base_popup.rs
@@ -38,6 +38,14 @@ pub fn get_default_popup_keymap() -> HashMap<(Mode, Vec<KeyEvent>), Action> {
     keymap
 }
 
+/// Represents the base functionality of a popup or a plugin/functionality
+///
+/// # Fields
+///
+/// - should_quit: bool
+/// - query: Query
+/// - keymap: HashMap<(Mode, Vec<KeyEvent>), Action>
+///
 #[derive(Debug, Clone, PartialEq)]
 pub struct BasePopUp {
     pub should_quit: bool,
@@ -45,12 +53,14 @@ pub struct BasePopUp {
     pub keymap: HashMap<(Mode, Vec<KeyEvent>), Action>,
 }
 
+/// Represents the behaviour of a popup - its resulting action and how it's displayed.
 pub trait Popupbehaviour {
     fn popup_title(&self) -> String;
     fn confirm_action(&self, query: String) -> Action;
     fn display_details(&self) -> String;
 }
 
+/// Generic popup encapsulating a popup behaviour and display details.
 #[derive(Debug, Clone, PartialEq)]
 pub struct GenericPopUp<T: Popupbehaviour> {
     pub base: BasePopUp,

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,9 @@ Currently under development and unstable.
 | `dd`          | Delete selected item                                                          |
 | `yy`          | Copy selected item to clipboard                                               |
 | `p`           | Paste from clipboard                                                          |
+| `a`           | Add new item                                                                  |
 | `r`           | Rename selected item                                                          |
+| `R`           | Copy and rename selected item                                                 |
 | `u`           | Undo last action (delete/rename)                                              |
 | `<C-r>`       | Redo last action (delete/rename)                                              |
 | `n`           | Next search result                                                            |


### PR DESCRIPTION
# Release notes

Introduce the ability to create an empty file within the current directory.
Allow to copy and rename a file with one shortcut.

# Pull request overview

This merge introduces two new actions (`AddDir`, `CopyRenameActive`).

# Outline of changes

- Introduce `GenericPopUp` to better manage different popups used to produce an `Action`. `GenericPopUp` consists of `BasePopUp`, which defines the keymaps, and `PopupBehaviour` which defines the `Action` produced by the popup as well as display details.
- Use the `GenericPopUp` struct to represent `rename` popup. Use a flag in `RenameBehaviour` to enable both renaming and copy-renaming. Use `GenericPopUp` to produce the popup producing the `AddDir` action.
- Add `AddDir` and `CopyRenameActive` actions.

# Quality checks

- [x] Removed all unnecessary imports (as much as reasonably possible)
- [x] Added units tests for the new code
- [x] All unit tests pass
- [x] Added all new shortcuts to `README.md`
- [x] Updated the `README.md` roadmap
- [x] Removed unnecessary debug outputs
- [x] Updated version number
- [x] Added docs to new functions
