### PR TITLE
Feature/try close popup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "blaze_explorer_macro_tests"
+version = "0.1.0"
+dependencies = [
+ "blaze_explorer_lib",
+ "blaze_explorer_macros",
+]
+
+[[package]]
+name = "blaze_explorer_macros"
+version = "0.1.0"
+dependencies = [
+ "blaze_explorer_lib",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bstr"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "blaze_explorer"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "blaze_explorer_lib",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "blaze_explorer"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "blaze_explorer_lib",
  "chrono",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "blaze_explorer_lib"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "clipboard-win",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["blaze_explorer", "blaze_explorer_lib"]
+members = ["blaze_explorer", "blaze_explorer_lib", "blaze_explorer_macros", "blaze_explorer_macro_tests"]
 resolver = "3"

--- a/blaze_explorer/Cargo.toml
+++ b/blaze_explorer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["tomblazejewski <tomi.blazejewski@gmail.com>"]
 name = "blaze_explorer"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 
 [dependencies]

--- a/blaze_explorer/src/main.rs
+++ b/blaze_explorer/src/main.rs
@@ -66,7 +66,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         loop {
             stdout().execute(EnterAlternateScreen)?;
             enable_raw_mode()?;
-            let result = app.run(cold_start);
+            let result = app.run(cold_start, false);
             cold_start = false;
             stdout().execute(LeaveAlternateScreen)?;
             disable_raw_mode()?;

--- a/blaze_explorer_lib/Cargo.toml
+++ b/blaze_explorer_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["tomblazejewski <tomi.blazejewski@gmail.com>"]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 name = "blaze_explorer_lib"
 

--- a/blaze_explorer_lib/src/app.rs
+++ b/blaze_explorer_lib/src/app.rs
@@ -189,7 +189,6 @@ impl App {
 
     pub fn try_drop_popup(&mut self) {
         if let Some(popup) = &mut self.popup {
-            println!("Trying to close popup: {}", popup.display_details());
             popup.quit();
         }
     }

--- a/blaze_explorer_lib/src/app.rs
+++ b/blaze_explorer_lib/src/app.rs
@@ -208,6 +208,7 @@ impl App {
         self.check_popup();
         if !test_mode {
             loop {
+                let _ = self.render();
                 if let event::Event::Key(key) = self.draw_key_event()? {
                     self.process_key_event(key);
                     self.check_popup();
@@ -663,4 +664,5 @@ mod tests {
         assert!(app.popup.is_none());
         assert_eq!(app.mode, Mode::Normal);
     }
+
 }

--- a/blaze_explorer_lib/src/app.rs
+++ b/blaze_explorer_lib/src/app.rs
@@ -187,8 +187,9 @@ impl App {
         }
     }
 
-    fn try_drop_popup(&mut self) {
+    pub fn try_drop_popup(&mut self) {
         if let Some(popup) = &mut self.popup {
+            println!("Trying to close popup: {}", popup.display_details());
             popup.quit();
         }
     }

--- a/blaze_explorer_lib/src/app.rs
+++ b/blaze_explorer_lib/src/app.rs
@@ -172,6 +172,7 @@ impl App {
             self.handle_key_event(key);
         };
     }
+    /// Check if the popup issued a quite command and wants to be dropped.
     fn check_popup(&mut self) {
         match &self.popup {
             None => {}
@@ -185,8 +186,16 @@ impl App {
             }
         }
     }
-    pub fn run(&mut self, cold_start: bool) -> Result<ExitResult> {
-        self.terminal.clear()?;
+
+    fn try_drop_popup(&mut self) {
+        if let Some(popup) = &mut self.popup {
+            popup.quit();
+        }
+    }
+    pub fn run(&mut self, cold_start: bool, test_mode: bool) -> Result<ExitResult> {
+        if !test_mode {
+            self.terminal.clear()?;
+        }
         if cold_start {
             let path = "./";
             let starting_path = path::absolute(path).unwrap();
@@ -194,16 +203,19 @@ impl App {
                 starting_path,
             )));
         }
+        // pricess new actions upon app start-up
         let _ = self.handle_new_actions();
-        loop {
-            let _ = self.render();
-            if let event::Event::Key(key) = self.draw_key_event()? {
-                self.process_key_event(key);
-                self.check_popup();
-                if self.should_quit {
-                    break;
+        self.check_popup();
+        if !test_mode {
+            loop {
+                if let event::Event::Key(key) = self.draw_key_event()? {
+                    self.process_key_event(key);
+                    self.check_popup();
+                    if self.should_quit {
+                        break;
+                    }
+                    let _ = self.handle_new_actions();
                 }
-                let _ = self.handle_new_actions();
             }
         }
 
@@ -542,6 +554,8 @@ mod tests {
 
     use ratatui::crossterm::event::{KeyCode, KeyModifiers};
 
+    use crate::plugin::plugin_helpers::DummyPluginPopUp;
+
     use super::*;
 
     #[test]
@@ -625,5 +639,28 @@ mod tests {
         assert!(data_dir.exists());
         fs::remove_dir_all(cache_dir).unwrap();
         fs::remove_dir_all(data_dir).unwrap();
+    }
+
+    #[test]
+    fn test_try_close_existing_popup() {
+        let mut app: App = App::new_test().unwrap();
+        let popup = DummyPluginPopUp::new();
+        app.attach_popup(Box::new(popup.clone()));
+
+        app.try_drop_popup();
+        app.run(false, true).unwrap();
+
+        assert!(app.popup.is_none());
+        assert_eq!(app.mode, Mode::Normal);
+    }
+    #[test]
+    fn test_try_close_no_popup() {
+        let mut app: App = App::new_test().unwrap();
+
+        app.try_drop_popup();
+        app.run(false, true).unwrap();
+
+        assert!(app.popup.is_none());
+        assert_eq!(app.mode, Mode::Normal);
     }
 }

--- a/blaze_explorer_lib/src/plugin/plugin_helpers.rs
+++ b/blaze_explorer_lib/src/plugin/plugin_helpers.rs
@@ -139,7 +139,6 @@ impl PluginPopUp for DummyPluginPopUp {
     }
 
     fn quit(&mut self) {
-        println!("DummyPluginPopUp: Quit called");
         self.should_quit = true
     }
 

--- a/blaze_explorer_lib/src/plugin/plugin_helpers.rs
+++ b/blaze_explorer_lib/src/plugin/plugin_helpers.rs
@@ -139,6 +139,7 @@ impl PluginPopUp for DummyPluginPopUp {
     }
 
     fn quit(&mut self) {
+        println!("DummyPluginPopUp: Quit called");
         self.should_quit = true
     }
 

--- a/blaze_explorer_macro_tests/Cargo.toml
+++ b/blaze_explorer_macro_tests/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "blaze_explorer_macro_tests"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+blaze_explorer_macros = { path = "../blaze_explorer_macros" }
+blaze_explorer_lib = { path = "../blaze_explorer_lib" }

--- a/blaze_explorer_macro_tests/src/lib.rs
+++ b/blaze_explorer_macro_tests/src/lib.rs
@@ -1,0 +1,33 @@
+#[cfg(test)]
+mod tests {
+    use blaze_explorer_lib::plugin::{plugin_helpers::DummyPluginPopUp, plugin_popup::PluginPopUp};
+    use blaze_explorer_macros::quit_popup;
+
+    use super::*;
+
+    #[test]
+    fn test_quit_popup_macro() {
+        use blaze_explorer_lib::app::App;
+        use blaze_explorer_macros::quit_popup;
+        trait DummyTrait {
+            fn dummy_function(&mut self);
+        }
+        impl DummyTrait for App {
+            #[quit_popup]
+            fn dummy_function(&mut self) {
+                // This function should have app.try_drop_popup() injected at the start
+            }
+        }
+
+        let mut app = App::new_test().unwrap();
+        let popup = DummyPluginPopUp::new();
+        app.attach_popup(Box::new(popup));
+
+        app.dummy_function();
+        if let Some(popup) = app.popup {
+            assert!(popup.should_quit());
+        } else {
+            panic!("Popup should not be None");
+        }
+    }
+}

--- a/blaze_explorer_macros/Cargo.toml
+++ b/blaze_explorer_macros/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+authors = ["tomblazejewski <tomi.blazejewski@gmail.com>"]
+name = "blaze_explorer_macros"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "2.0"
+quote = "1.0"
+blaze_explorer_lib = { path = "../blaze_explorer_lib" }
+

--- a/blaze_explorer_macros/src/lib.rs
+++ b/blaze_explorer_macros/src/lib.rs
@@ -5,6 +5,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{ItemFn, parse_macro_input};
 
+/// Try dropping the poupup as a first action in the function body.
 #[proc_macro_attribute]
 pub fn quit_popup(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut input_fn = parse_macro_input!(item as ItemFn);

--- a/blaze_explorer_macros/src/lib.rs
+++ b/blaze_explorer_macros/src/lib.rs
@@ -1,0 +1,22 @@
+extern crate proc_macro;
+
+use blaze_explorer_lib::app::App;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{ItemFn, parse_macro_input};
+
+#[proc_macro_attribute]
+pub fn quit_popup(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let mut input_fn = parse_macro_input!(item as ItemFn);
+
+    // inject `app.try_drop_popup();` at the start of the function body
+    let stmts = &mut input_fn.block.stmts;
+    let injected: syn::Stmt = syn::parse_quote! {
+        self.try_drop_popup();
+    };
+    stmts.insert(0, injected);
+
+    TokenStream::from(quote! {
+        #input_fn
+    })
+}


### PR DESCRIPTION
# Release notes

Introduce a `quitpopup` procedural macro to avoid code repetition.

# Pull request overview

This merge introduces a new crate containing a macro to try to close a popup on the `App` struct if one is attached.

# Outline of changes

- Add a new crate `blaze_explorer_macros`  containing quite popup macro.
- Add a testing mode to the `App` so it's possible to run it without clearing the terminal window.

# Quality checks

- [x] Removed all unnecessary imports (as much as reasonably possible)
- [x] Added units tests for the new code
- [x] All unit tests pass
- [x] Added all new shortcuts to `README.md`
- [x] Updated the `README.md` roadmap
- [x] Removed unnecessary debug outputs
- [x] Updated version number
- [x] Added docs to new functions
